### PR TITLE
Fix tf2comp's on_raw_reaction functions not checking if message is a vote message

### DIFF
--- a/cogs/tf2comp.py
+++ b/cogs/tf2comp.py
@@ -96,32 +96,33 @@ class TF2Comp(commands.Cog):
             return
 
         try:
-            if payload.message_id == self.vote_message_id:
-                is_main = any(role.id in main_roles for role in member.roles)
-                class_role = any(role.id in roster_roles for role in member.roles)
-                if payload.emoji.name == u'\u2705':
-                    if is_main and class_role:
-                        for role in member.roles:
-                            if role.id in config.roster_roles:
-                                class_id = config.roster_roles.index(role.id)
-                                embed.set_field_at(index=class_id, name=str(ClassEnum(class_id).name), value="Yes", inline=True)
-                                self.available_players.append(payload.user_id)
-                                await vote_message.edit(embed=embed)
-                                break
-                    else:
-                        await vote_message.remove_reaction(u'\u2705', member)
+            is_main = any(role.id in main_roles for role in member.roles)
+            class_role = any(role.id in roster_roles for role in member.roles)
+            if payload.emoji.name == u'\u2705':
+                if is_main and class_role:
+                    for role in member.roles:
+                        if role.id in config.roster_roles:
+                            class_id = config.roster_roles.index(role.id)
 
-                if payload.emoji.name == u'\u274E':
-                    if is_main and class_role:
-                        for role in payload.member.roles:
-                            if role.id in config.roster_roles:
-                                class_id = config.roster_roles.index(role.id)
-                                embed.set_field_at(index=class_id, name=str(ClassEnum(class_id).name), value="No", inline=True)
-                                self.unavailable_players.append(payload.user_id)
-                                await vote_message.edit(embed=embed)
-                                break
-                    else:
-                        await vote_message.remove_reaction(u'\u274E', member)
+                            embed.set_field_at(index=class_id, name=str(ClassEnum(class_id).name), value="Yes", inline=True)
+                            self.available_players.append(payload.user_id)
+                            await vote_message.edit(embed=embed)
+                            break
+                else:
+                    await vote_message.remove_reaction(u'\u2705', member)
+
+            if payload.emoji.name == u'\u274E':
+                if is_main and class_role:
+                    for role in payload.member.roles:
+                        if role.id in config.roster_roles:
+                            class_id = config.roster_roles.index(role.id)
+
+                            embed.set_field_at(index=class_id, name=str(ClassEnum(class_id).name), value="No", inline=True)
+                            self.unavailable_players.append(payload.user_id)
+                            await vote_message.edit(embed=embed)
+                            break
+                else:
+                    await vote_message.remove_reaction(u'\u274E', member)
         except Exception as e:
             self.client.log.exception(e)
 
@@ -142,30 +143,29 @@ class TF2Comp(commands.Cog):
             return
 
         try:
-            if payload.message_id == self.vote_message_id:
-                is_main = any(role.id in main_roles for role in member.roles)
-                class_role = any(role.id in roster_roles for role in member.roles)
-                if payload.emoji.name == u'\u2705':
-                    if is_main and class_role:
-                        for role in member.roles:
-                            if role.id in config.roster_roles:
-                                class_id = config.roster_roles.index(role.id)
+            is_main = any(role.id in main_roles for role in member.roles)
+            class_role = any(role.id in roster_roles for role in member.roles)
+            if payload.emoji.name == u'\u2705':
+                if is_main and class_role:
+                    for role in member.roles:
+                        if role.id in config.roster_roles:
+                            class_id = config.roster_roles.index(role.id)
 
-                                embed.set_field_at(index=class_id, name=str(ClassEnum(class_id).name), value="?", inline=True)
-                                self.available_players.remove(payload.user_id)
-                                await vote_message.edit(embed=embed)
-                                break
+                            embed.set_field_at(index=class_id, name=str(ClassEnum(class_id).name), value="?", inline=True)
+                            self.available_players.remove(payload.user_id)
+                            await vote_message.edit(embed=embed)
+                            break
 
-                if payload.emoji.name == u'\u274E':
-                    if is_main and class_role:
-                        for role in member.roles:
-                            if role.id in config.roster_roles:
-                                class_id = config.roster_roles.index(role.id)
+            if payload.emoji.name == u'\u274E':
+                if is_main and class_role:
+                    for role in member.roles:
+                        if role.id in config.roster_roles:
+                            class_id = config.roster_roles.index(role.id)
 
-                                embed.set_field_at(index=class_id, name=str(ClassEnum(class_id).name), value="?", inline=True)
-                                self.unavailable_players.remove(payload.user_id)
-                                await vote_message.edit(embed=embed)
-                                break
+                            embed.set_field_at(index=class_id, name=str(ClassEnum(class_id).name), value="?", inline=True)
+                            self.unavailable_players.remove(payload.user_id)
+                            await vote_message.edit(embed=embed)
+                            break
         except Exception as e:
             self.client.log.exception(e)
 

--- a/cogs/tf2comp.py
+++ b/cogs/tf2comp.py
@@ -81,6 +81,9 @@ class TF2Comp(commands.Cog):
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):
+        if payload.message_id != self.vote_message_id:
+            return
+
         global embed
         main_roles = config.main_or_sub
         roster_roles = config.roster_roles
@@ -124,6 +127,9 @@ class TF2Comp(commands.Cog):
 
     @commands.Cog.listener()
     async def on_raw_reaction_remove(self, payload):
+        if payload.message_id != self.vote_message_id:
+            return
+
         global embed
         main_roles = config.main_or_sub
         roster_roles = config.roster_roles


### PR DESCRIPTION
Currently the availability vote feature checks whether the message that was reacted to is a valid availability vote message too late, resulting in an error that isn't handled.